### PR TITLE
Add Jenkins scripts to build to be versioned with code

### DIFF
--- a/build/build_docker.sh
+++ b/build/build_docker.sh
@@ -1,0 +1,12 @@
+buildDockerImage() {
+   DIRECTORY=$1
+   LOWER_DIRECTORY=$(echo $DIRECTORY | tr '[:upper:]' '[:lower:]')
+   WEB_IMAGE_NAME="${ACR_LOGINSERVER}/$LOWER_DIRECTORY:kube${BUILD_NUMBER}"
+   docker build -t $WEB_IMAGE_NAME $DIRECTORY
+}  
+
+dirs=`find -name "Dockerfile" | xargs dirname | cut -c 3-`
+
+for directory in $dirs; do
+	buildDockerImage $directory
+done

--- a/build/install.sh
+++ b/build/install.sh
@@ -6,5 +6,5 @@ pip3 install pylint
 pip3 install pylint_runner
 pip3 install pytest
 pip3 install pytest-cov
-pip3 install $parentDir/credscan --upgrade
-find $parentDir -name "requirements.txt" | xargs -I {} pip install -r {}
+pip3 install "$parentDir/credscan" --upgrade
+find "$parentDir" -name "requirements.txt" | xargs -I {} pip install -r {}

--- a/build/install.sh
+++ b/build/install.sh
@@ -1,0 +1,9 @@
+parentDir=$(dirname $(dirname $(readlink -f "$0")))
+
+# Install the dependency required to build the project
+pip3 install pylint
+pip3 install pylint_runner
+pip3 install pytest
+pip3 install pytest-cov
+pip3 install $parentDir/credscan --upgrade
+find $parentDir -name "requirements.txt" | xargs -I {} pip install -r {}

--- a/build/install.sh
+++ b/build/install.sh
@@ -1,4 +1,6 @@
-parentDir=$(dirname $(dirname $(readlink -f "$0")))
+current_file_path=$(readlink -f '$0')
+this_file_directory=$(dirname "$current_file_path")
+parentDir=$(dirname "$this_file_directory")
 
 # Install the dependency required to build the project
 pip3 install pylint

--- a/build/install.sh
+++ b/build/install.sh
@@ -1,6 +1,5 @@
 current_file_path=$(readlink -f '$0')
-this_file_directory=$(dirname "$current_file_path")
-parentDir=$(dirname "$this_file_directory")
+parentDir=$(dirname "$current_file_path")
 
 # Install the dependency required to build the project
 pip3 install pylint

--- a/build/official.sh
+++ b/build/official.sh
@@ -1,0 +1,11 @@
+chmod +x ./build/install.sh
+chmod +x ./build/validate.sh
+
+./build/install.sh
+./build/validate.sh
+
+chmod +x ./build/build_docker.sh
+chmod +x ./build/push_docker.sh
+
+./build/build_docker.sh
+./build/push_docker.sh

--- a/build/precheckin.sh
+++ b/build/precheckin.sh
@@ -1,0 +1,9 @@
+chmod +x ./build/install.sh
+chmod +x ./build/validate.sh
+
+./build/install.sh
+./build/validate.sh
+
+chmod +x ./build/build_docker.sh
+
+./build/build_docker.sh

--- a/build/push_docker.sh
+++ b/build/push_docker.sh
@@ -1,0 +1,12 @@
+pushDockerImage() {
+   DIRECTORY=$1
+   LOWER_DIRECTORY=$(echo $DIRECTORY | tr '[:upper:]' '[:lower:]')
+   WEB_IMAGE_NAME="${ACR_LOGINSERVER}/$LOWER_DIRECTORY:kube${BUILD_NUMBER}"
+   docker push $WEB_IMAGE_NAME
+}  
+
+dirs=`find -name "Dockerfile" | xargs dirname | cut -c 3-`
+
+for directory in $dirs; do
+	pushDockerImage $directory
+done

--- a/build/validate.sh
+++ b/build/validate.sh
@@ -3,7 +3,7 @@ parentDir=$(dirname "$current_file_path")
 
 
 # Run the linter on every file
-pylint_runner $parentDir
+pylint_runner "$parentDir"
 
 # Run test coverage on the project
-py.test --cov=$parentDir --cov-report=xml $parentDir
+py.test --cov="$parentDir" --cov-report=xml "$parentDir"

--- a/build/validate.sh
+++ b/build/validate.sh
@@ -1,0 +1,7 @@
+parentDir=$(dirname $(dirname $(readlink -f "$0")))
+
+# Run the linter on every file
+pylint_runner $parentDir
+
+# Run test coverage on the project
+py.test --cov=$parentDir --cov-report=xml $parentDir

--- a/build/validate.sh
+++ b/build/validate.sh
@@ -1,6 +1,5 @@
 current_file_path=$(readlink -f '$0')
-this_file_directory=$(dirname "$current_file_path")
-parentDir=$(dirname "$this_file_directory")
+parentDir=$(dirname "$current_file_path")
 
 
 # Run the linter on every file

--- a/build/validate.sh
+++ b/build/validate.sh
@@ -1,4 +1,7 @@
-parentDir=$(dirname $(dirname $(readlink -f "$0")))
+current_file_path=$(readlink -f '$0')
+this_file_directory=$(dirname "$current_file_path")
+parentDir=$(dirname "$this_file_directory")
+
 
 # Run the linter on every file
 pylint_runner $parentDir


### PR DESCRIPTION
Each of these scripts will be called by Jenkins instead of having the scripts defined in Jenkins. They are split up so we can run some or all of the scripts, depending on the build (ex: Pre-checkin doesn't push the Docker image).